### PR TITLE
Bootstrap the Red Hat product devfile registry

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,11 +1,3 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
 FROM quay.io/openshift-pipeline/golang:1.15-alpine AS builder
 
 # Install dependencies

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FROM quay.io/openshift-pipeline/golang:1.15-alpine AS builder
+
+# Install dependencies
+
+RUN apk add --no-cache git bash curl zip
+
+# Install yq
+RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64 -o /usr/local/bin/yq && mv ./yq_linux_amd64 /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+
+COPY . /registry
+
+# Download the registry build tools
+RUN git clone https://github.com/devfile/registry-support.git /registry-support
+
+# Run the registry build tools
+RUN /registry-support/build-tools/build.sh /registry /build
+
+FROM quay.io/devfile/devfile-index-base:next
+
+COPY --from=builder /build /registry

--- a/.ci/acceptance-tests/devfile-registry-acceptance.yaml
+++ b/.ci/acceptance-tests/devfile-registry-acceptance.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: devfile-registry-acceptance
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: devfile-registry-acceptance-${JOB_NAME}
+  spec:
+    backoffLimit: 5
+    template:
+      spec:
+        restartPolicy: Never
+        containers:
+          - image: ${IMAGE}:${IMAGE_TAG}
+            imagePullPolicy: Always
+            name: github-mirror-acceptance
+            env:
+              - name: REGISTRY
+                value: ${REGISTRY}
+parameters:
+- name: IMAGE
+  value: quay.io/devfile/devfile-registry-integration
+- name: IMAGE_TAG
+  value: "next"
+  required: true
+- name: REGISTRY
+  value: "https://registry.stage.devfile.io"
+  required: true
+- name: JOB_NAME
+  generate: expression
+  from: "[a-z0-9]{5}"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#!/usr/bin/env bash
+# This script downloads the registry build tools and builds up this repository
+# This script runs on both the GitHub action CI and the CICD for the hosted registry
+
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+docker build --no-cache -t devfile-index -f $ABSOLUTE_PATH/Dockerfile $ABSOLUTE_PATH/..

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,12 +1,3 @@
-#
-# Copyright (c) 2021 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-
 #!/usr/bin/env bash
 # This script downloads the registry build tools and builds up this repository
 # This script runs on both the GitHub action CI and the CICD for the hosted registry

--- a/.ci/build_and_deploy.sh
+++ b/.ci/build_and_deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# This script downloads the registry build tools and builds up this repository then pushes it to quay.io
+# This will be run via the app-sre CI.
+set -ex
+ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_REV="$(git rev-parse --short=7 HEAD)"
+IMAGE="${IMAGE:-quay.io/app-sre/product-devfile-index}"
+IMAGE_TAG="${IMAGE_TAG:-${GIT_REV}}"
+
+# Run the build script
+$ABSOLUTE_PATH/build.sh
+
+# Push the iamge to quay.io
+if [[ -n "$QUAY_USER" && -n "$QUAY_TOKEN" ]]; then
+    DOCKER_CONF="$PWD/.docker"
+    mkdir -p "$DOCKER_CONF"
+    docker tag devfile-index "${IMAGE}:${IMAGE_TAG}"
+    docker tag devfile-index "${IMAGE}:next"
+    docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
+    docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:next"
+fi

--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -1,0 +1,187 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: devfile-registry
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: devfile-registry
+    name: devfile-registry
+  spec:
+    replicas: ${{REPLICAS}}
+    selector:
+      matchLabels:
+        app: devfile-registry
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+    template:
+      metadata:
+        labels:
+          app: devfile-registry
+      spec:
+        volumes:
+          - name: devfile-registry-storage
+            emptyDir: {}
+          - name: config
+            configMap:
+              name: devfile-registry
+              items:
+                - key: registry-config.yml
+                  path: config.yml
+        containers:
+        - image: ${DEVFILE_INDEX_IMAGE}:${DEVFILE_INDEX_IMAGE_TAG}
+          imagePullPolicy: "${DEVFILE_INDEX_PULL_POLICY}"
+          name: devfile-registry
+          ports:
+          - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+            limits:
+              cpu: 100m
+              memory: ${DEVFILE_INDEX_MEMORY_LIMIT}
+        - image: ${OCI_REGISTRY_IMAGE}:${OCI_REGISTRY_IMAGE_TAG}
+          imagePullPolicy: "${OCI_REGISTRY_PULL_POLICY}"
+          name: oci-registry
+          livenessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /v2/
+              port: 5000
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+            limits:
+              cpu: 100m
+              memory: ${OCI_REGISTRY_MEMORY_LIMIT}
+          volumeMounts:
+          - name: devfile-registry-storage
+            mountPath: "/var/lib/registry"
+          - name: config
+            mountPath: "/etc/docker/registry"
+            readOnly: true
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: devfile-registry
+    labels:
+      app: devfile-registry
+  spec:
+    ports:
+      - name: http
+        protocol: TCP
+        port: 8080
+        targetPort: 8080
+      - name: oci-metrics
+        protocol: TCP
+        port: 5001
+        targetPort: 5001
+      - name: index-metrics
+        protocol: TCP
+        port: 7071
+        targetPort: 7071
+    selector:
+      app: devfile-registry
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: devfile-registry
+    annotations:
+      qontract.recycle: "true"
+  data:
+    registry-config.yml: |
+      version: 0.1
+      log:
+        fields:
+          service: registry
+      storage:
+        cache:
+          blobdescriptor: inmemory
+        filesystem:
+          rootdirectory: /var/lib/registry
+      http:
+        addr: :5000
+        headers:
+          X-Content-Type-Options: [nosniff]
+        debug:
+          addr: :5001
+          prometheus:
+            enabled: true
+            path: /metrics
+
+parameters:
+- name: DEVFILE_INDEX_IMAGE
+  value: quay.io/app-sre/product-devfile-index
+  displayName: Devfile registry index image
+  description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
+- name: DEVFILE_INDEX_IMAGE_TAG
+  value: next
+  displayName: Devfile registry version
+  description: Devfile registry version which defaults to next
+- name: DEVFILE_INDEX_MEMORY_LIMIT
+  value: 256Mi
+  displayName: Memory Limit
+  description: Maximum amount of memory the container can use. Defaults 256Mi
+- name: DEVFILE_INDEX_PULL_POLICY
+  value: Always
+  displayName: Devfile registry image pull policy
+  description: Always pull by default. Can be IfNotPresent
+- name: OCI_REGISTRY_IMAGE
+  value: quay.io/devfile/oci-registry
+  displayName: OCI registry index image
+  description: OCI registry index docker image. Defaults to quay.io/devfile/devfile-index
+- name: OCI_REGISTRY_IMAGE_TAG
+  value: next
+  displayName: OCI registry version
+  description: OCI registry version which defaults to next
+- name: OCI_REGISTRY_MEMORY_LIMIT
+  value: 256Mi
+  displayName: Memory Limit
+  description: Maximum amount of memory the OCI registry container can use. Defaults 256Mi
+- name: OCI_REGISTRY_PULL_POLICY
+  value: Always
+  displayName: Devfile registry image pull policy
+  description: Always pull by default. Can be IfNotPresent
+- name: REPLICAS
+  value: "1"
+  displayName: Devfile registry replicas
+  description: The number of replicas for the hosted devfile registry service

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,3 @@
-#
-# Copyright (c) 2020 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
 name: CI
 
 on:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Check registry build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: registry-repo
+    - name: Setup Go environment
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.13
+    
+    - name: Check if devfile registry build is working
+      run: registry-repo/.ci/build.sh

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # devfile-registry
+
 Source repository for the Red Hat product devfile registry
+
+This product devfile registry is updated weekly, by 12pm EST Wednesdays, with any updated stacks in this repository.
+
+## Registry Updates
+
+The staging product devfile registry is refreshed upon each commit to main in this repository. Production is promoted manually and as mentioned above, is done each Wednesday, as needed.
+
+If you are a stack owner and need to request an urgent refresh of the registry service before Wednesday (for example if a stack is broken), please open an issue in this repository outlining the following:
+
+- Stack name
+- Why the refresh is needed
+- Why the refresh cannot wait until the next regularly scheduled refresh
+
+## Developing
+
+### Prerequisites
+
+- Docker 17.06 or later
+- Git
+
+### Build
+
+To build this devfile registry into a container image run `.ci/build.sh`. A container image will be built using the [devfile registry build tools](https://github.com/devfile/registry-support/tree/master/build-tools).
+
+From there, push the container image to a container registry of your choice and deploy using one of the methods outlined [here](https://github.com/devfile/registry-support#deploy).
+
+## Contributing
+
+For contributing Devfile stacks to this registry, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+
+## Reporting any issue
+
+For issues relating to a specific devfile stack in this repository, please reach out to the devfile stack maintainer to determine where to open an issue.
+
+For issues relating to the hosted product devfile registry service in general, please use this repository for opening issues.

--- a/stacks/java-jboss-eap-xp-bootable-jar/devfile.yaml
+++ b/stacks/java-jboss-eap-xp-bootable-jar/devfile.yaml
@@ -1,0 +1,173 @@
+schemaVersion: 2.0.0
+metadata:
+  name: java-jboss-eap-xp-bootable-jar
+  version: 1.0.0
+  website: https://access.redhat.com/products/red-hat-jboss-enterprise-application-platform/
+starterProjects:
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile Config Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-config
+  - name: microprofile-fault-tolerance
+    description: EAP XP 2.0 Eclipse Microprofile Fault Tolerance Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-fault-tolerance
+  - name: microprofile-health
+    description: EAP XP 2.0 Eclipse Microprofile Health Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-health
+  - name: microprofile-jwt
+    description: EAP XP 2.0 Eclipse Microprofile JWT Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-jwt
+  - name: microprofile-metrics
+    description: EAP XP 2.0 Eclipse Microprofile Metrics Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-metrics
+  - name: microprofile-openapi
+    description: EAP XP 2.0 Eclipse Microprofile OpenAPI Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-openapi
+  - name: microprofile-opentracing
+    description: EAP XP 2.0 Eclipse Microprofile OpenTracing Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-opentracing
+  - name: microprofile-rest-client
+    description: EAP XP 2.0 Eclipse Microprofile REST Client Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-rest-client
+components:
+  - name: jaeger
+    container:
+      image: quay.io/jaegertracing/all-in-one:1.21.0
+      memoryLimit: 128Mi
+      endpoints:
+        - name: 'tracing-ui'
+          targetPort: 16686
+  - name: eap-xp
+    container:
+      image: registry.access.redhat.com/ubi8/openjdk-11
+      memoryLimit: 1512Mi
+      mountSources: true
+      volumeMounts:
+        - name: m2-repository
+          path: /home/jboss/.m2/repository
+      env:
+        # Enabling Jaeger tracing
+        - name: WILDFLY_TRACING_ENABLED
+          value: 'true'
+        # Define the Jaeger service name 
+        - name: JAEGER_SERVICE_NAME
+          value: 'microprofile-opentracing'
+        # Configure Jaeger traces
+        - name: JAEGER_REPORTER_LOG_SPANS 
+          value: 'true'
+        - name: JAEGER_SAMPLER_TYPE
+          value: 'const'
+        - name: JAEGER_SAMPLER_PARAM
+          value: '1'
+        - name: GC_METASPACE_SIZE
+          value: '96'
+        - name: GC_MAX_METASPACE_SIZE
+          value: '256'
+        - name: JAVA_OPTS
+          value: '-Djava.security.egd=file:/dev/urandom'
+        - name: MVN_ARGS_APPEND
+          value: '-Pbootable-jar -s /home/jboss/.m2/settings.xml -Dmaven.repo.local=/home/jboss/.m2/repository -Dcom.redhat.xpaas.repo.jbossorg'
+      endpoints:
+        - name: 'http'
+          targetPort: 8080
+  - name: m2-repository
+    volume:
+      size: 3Gi
+commands:
+  - id: build
+    exec:
+      component: eap-xp
+      commandLine: mvn ${MVN_ARGS_APPEND} clean package
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: eap-xp
+      commandLine: mvn ${MVN_ARGS_APPEND} -Dwildfly.bootable.arguments="-b=0.0.0.0" wildfly-jar:run
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      component: eap-xp
+      commandLine: mvn ${MVN_ARGS_APPEND} -Dwildfly.bootable.arguments="-b=0.0.0.0" -Dwildfly.bootable.jvmArguments="-agentlib:jdwp=transport=dt_socket,address=0.0.0.0:${DEBUG_PORT},server=y,suspend=n" wildfly-jar:run
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: debug
+        isDefault: true
+  - id: dev-build
+    exec:
+      component: eap-xp
+      commandLine: mvn ${MVN_ARGS_APPEND} -Dmaven.test.skip=true -Ddev package
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: build
+        isDefault: false
+  - id: dev-run
+    exec:
+      component: eap-xp
+      commandLine: mvn ${MVN_ARGS_APPEND} wildfly-jar:dev
+      workingDir: $PROJECTS_ROOT
+      hotReloadCapable: true
+      group:
+        kind: run
+        isDefault: false
+  - id: dev-debug
+    exec:
+      component: eap-xp
+      commandLine: mvn ${MVN_ARGS_APPEND} -Dwildfly.bootable.arguments="-b=0.0.0.0" -Dwildfly.bootable.jvmArguments="-agentlib:jdwp=transport=dt_socket,address=0.0.0.0:${DEBUG_PORT},server=y,suspend=n" wildfly-jar:dev
+      workingDir: $PROJECTS_ROOT
+      hotReloadCapable: true
+      group:
+        kind: debug
+        isDefault: false


### PR DESCRIPTION
This PR bootstraps this repository with the necessary resources to build a hosted product devfile registry service:
- JBoss EAP stack
   - See commit https://github.com/redhat-developer/devfile-registry/commit/a8daa2d1c589c64eca654af28a8f6afdfa45fa6f
   - @ehsavoie I copied the stack from your PR in https://github.com/odo-devfiles/registry/pull/67, please let me know if any changes need to be made, or if there's any concerns
- Dockerfile and build scripts for building the product registry in AppSRE's pipelines
- OpenShift template yamls for deploying and testing the registry in AppSRE's pipelines
- Simple GitHub action to build the product registry on PRs

@elsony @GeekArthur Please review