### PR TITLE
Update OpenShift templates for registry

### DIFF
--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -184,7 +184,7 @@ objects:
 
 parameters:
 - name: DEVFILE_INDEX_IMAGE
-  value: quay.io/devfile/devfile-index
+  value: quay.io/app-sre/product-devfile-index
   displayName: Devfile registry index image
   description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
 - name: DEVFILE_INDEX_IMAGE_TAG

--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -42,6 +42,12 @@ objects:
               items:
                 - key: registry-config.yml
                   path: config.yml
+          - name: viewer-config
+            configMap:
+              name: devfile-registry
+              items:
+                - key: devfile-registry-hosts.json
+                  path: devfile-registry-hosts.json
         containers:
         - image: ${DEVFILE_INDEX_IMAGE}:${DEVFILE_INDEX_IMAGE_TAG}
           imagePullPolicy: "${DEVFILE_INDEX_PULL_POLICY}"
@@ -50,38 +56,59 @@ objects:
           - containerPort: 8080
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: 8080
-            initialDelaySeconds: 30
+              scheme: HTTP
+            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: 8080
-            initialDelaySeconds: 3
+              scheme: HTTP
+            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 3
+          startupProbe:
+            httpGet:
+              path: /viewer
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 10
           resources:
             requests:
-              cpu: 1m
-              memory: 5Mi
-            limits:
               cpu: 100m
+              memory: 64Mi
+            limits:
+              cpu: 250m
               memory: ${DEVFILE_INDEX_MEMORY_LIMIT}
+          env:
+            - name: DEVFILE_VIEWER_ROOT
+              value: "/viewer"
+            - name: ENABLE_TELEMETRY
+              value: ${ENABLE_TELEMETRY}
+            - name: REGISTRY_NAME
+              value: ${REGISTRY_NAME}
+          volumeMounts:
+          - name: viewer-config
+            mountPath: "/app/config"
+            readOnly: false
         - image: ${OCI_REGISTRY_IMAGE}:${OCI_REGISTRY_IMAGE_TAG}
           imagePullPolicy: "${OCI_REGISTRY_PULL_POLICY}"
           name: oci-registry
           livenessProbe:
             httpGet:
-              path: /v2/
+              path: /v2
               port: 5000
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
-              path: /v2/
+              path: /v2
               port: 5000
             initialDelaySeconds: 3
             periodSeconds: 10
@@ -148,9 +175,16 @@ objects:
             enabled: true
             path: /metrics
 
+    devfile-registry-hosts.json: |
+      {
+        "Community": {
+          "url": "http://localhost:8080"
+        }
+      }
+
 parameters:
 - name: DEVFILE_INDEX_IMAGE
-  value: quay.io/app-sre/product-devfile-index
+  value: quay.io/devfile/devfile-index
   displayName: Devfile registry index image
   description: Devfile registry index docker image. Defaults to quay.io/devfile/devfile-index
 - name: DEVFILE_INDEX_IMAGE_TAG
@@ -185,3 +219,11 @@ parameters:
   value: "1"
   displayName: Devfile registry replicas
   description: The number of replicas for the hosted devfile registry service
+- name: ENABLE_TELEMETRY
+  value: "false"
+  displayName: Devfile registry telemetry enablement
+  description: Option to opt in or opt out devfile registry telemetry
+- name: REGISTRY_NAME
+  value: devfile-community-registry
+  displayName: Devfile registry name
+  description: The registry name that is used as identifier for devfile telemetry

--- a/.ci/deploy/route.yaml
+++ b/.ci/deploy/route.yaml
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: devfile-registry
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: devfile-registry
+    name: devfile-registry
+  spec:
+    host: ${DEVFILE_REGISTRY_HOST}
+    to:
+      kind: Service
+      name: devfile-registry
+      weight: 100
+    port:
+      targetPort: 8080
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: devfile-registry
+    name: oci-registry
+  spec:
+    host: ${DEVFILE_REGISTRY_HOST}
+    path: /v2
+    to:
+      kind: Service
+      name: devfile-registry
+      weight: 100
+    port:
+      targetPort: 8080
+
+parameters:
+- name: DEVFILE_REGISTRY_HOST
+  value: ""
+  displayName: Devfile registry hostname
+  description: Hostname for the devfile registry service. Defaults to cluster's router.
+  required: false

--- a/stacks/java-jboss-eap-xp-bootable-jar/devfile.yaml
+++ b/stacks/java-jboss-eap-xp-bootable-jar/devfile.yaml
@@ -2,6 +2,10 @@ schemaVersion: 2.0.0
 metadata:
   name: java-jboss-eap-xp-bootable-jar
   version: 1.0.0
+  displayName: JBoss EAP XP
+  tags: ["Java", "JBoss"]
+  projectType: "jboss"
+  language: "java"
   website: https://access.redhat.com/products/red-hat-jboss-enterprise-application-platform/
 starterProjects:
   - name: microprofile-config


### PR DESCRIPTION
Update the OpenShift templates for this registry to match what's used in the community devfile registry.

Also adds some metadata that was missing from the jboss stack.