### PR TITLE
Miscellaneous updates to the registry

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -15,6 +15,6 @@ RUN git clone https://github.com/devfile/registry-support.git /registry-support
 # Run the registry build tools
 RUN /registry-support/build-tools/build.sh /registry /build
 
-FROM quay.io/devfile/devfile-index-base:next
+FROM quay.io/devfile/devfile-index-base:no-community
 
 COPY --from=builder /build /registry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to this registry
+
+This document outlines the requirements for contributing a devfile stack or sample to this repository.
+
+The [devfile registry structure](https://github.com/devfile/api/blob/main/docs/proposals/registry/registry-structure.md#repository-structure) design doc provides some useful background information on the structure of resources in a devfile registry (and its Git repository).
+
+## Prerequisites
+
+The following are required to build the devfile index container image containing your stack or sample:
+
+- Docker 17.06 or later
+- Git
+
+## Stacks
+
+### Contributing
+
+1) Verify your Devfile stack functions with odo.
+  
+    - Core odo functions such as `odo create --devfile <devfile.yaml>`, `odo push`, `odo url create` should work with the devfile.
+    - PR tests on this repository will verify this functionality as well.
+
+2) Verify your Devfile stack has the following metadata fields at a minimum:
+
+    - Name: The name of the devfile stack, e.g. `java-springboot`.
+    - Display Name: The longer name of your devfile stack, e.g. `Spring Boot®`.
+    - Description: A brief description of your devfile stack, e.g. `Spring Boot® using Java`.
+    - Version: The version of your stack, in semnatic version format, e.g. `1.0.0`.
+
+2) Add a folder for the stack to `stacks/` in this repository.
+  
+    - Make sure the name matches the devfile stack's name and be in the format `<language>-<framework>`. E.g. `java-quarkus`, `python-django`, etc.
+
+3) Add the devfile.yaml and any other necessary files for the stack under the stack folder.
+
+4) Run the `.ci/build.sh` to build the registry into a container image.
+  
+    - This will also validate the devfiles in this repository, making sure they conform to a minimum standard.
+    - This step will also be run in the PR build for the repository.
+
+5) Open a pull request against this repository with a brief description of the change.
+
+
+### Updating
+
+Updating an existing devfile stack is relatively straightforward:
+
+1) Find the stack under the `stacks/` folder that you wish to update.
+2) Make the necessary changes to the stack, such as: updating image tags, commands, starter projects, etc.
+3) Update the version of stack, following the [semantic versioning format](https://semver.org/).
+4) Test your changes:
+    
+    - Minimally, testing with odo (`odo create`, `odo push`, etc) is recommended, however if your Devfile is used with other tools, it's recommended to test there as well.
+5) Open a pull request against this repository with your changes.
+
+## Samples
+
+### Contributing
+
+The devfile samples used in this devfile registry are stored in the `extraDevfileEntries.yaml` file in the root of the repository. To add a devfile sample:
+
+1) Open `extraDevfileEntries.yaml` in an editor
+2) Add an entry to the file with the following required fields:
+```
+  - name: <sample-name>
+    displayName: <sample-display-name>
+    description: <sample-description>
+    icon: <link-to-sample-icon>
+    tags: ["comma", "separated", "list", "of", "tags"]
+    projectType: <sample-project-type>
+    language: <sample-language>
+    git:
+      remotes:
+        origin: <link-to-sample-git-repository>
+```
+3) Fill in the fields in the angle brackets based on your sample. Note that there must be only one git remote for the devfile sample. 
+4) Open a pull request against this repository with your changes.
+
+### Updating
+
+To update a sample:
+
+1) Open `extraDevfileEntries.yaml` in an editor.
+2) Find the entry for the sample you wish to update.
+3) Make the necessary changes.
+4) Open a pull request against this repository with your changes.

--- a/stacks/java-jboss-eap-xp-bootable-jar/devfile.yaml
+++ b/stacks/java-jboss-eap-xp-bootable-jar/devfile.yaml
@@ -2,9 +2,10 @@ schemaVersion: 2.0.0
 metadata:
   name: java-jboss-eap-xp-bootable-jar
   version: 1.0.0
-  displayName: JBoss EAP XP
-  tags: ["Java", "JBoss"]
-  projectType: "jboss"
+  displayName: JBoss EAP XP 2.0 Bootable Jar
+  description: Java stack with EAP XP 2.0 in bootable Jar mode, OpenJDK 11 and Maven 3.5
+  tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Microprofile", "EAP XP Bootable"]
+  projectType: "JBoss EAP XP"
   language: "java"
   website: https://access.redhat.com/products/red-hat-jboss-enterprise-application-platform/
 starterProjects:

--- a/stacks/java-jboss-eap-xp/devfile.yaml
+++ b/stacks/java-jboss-eap-xp/devfile.yaml
@@ -1,0 +1,226 @@
+schemaVersion: 2.0.0
+metadata:
+  name: java-jboss-eap-xp
+  version: 1.0.0
+  displayName: JBoss EAP XP 2.0
+  description: Java stack with EAP XP 2.0, OpenJDK 11 and Maven 3.5
+  tags: ["RHEL8", "Java", "OpenJDK", "Maven", "EAP", "Microprofile", "EAP XP"]
+  projectType: "JBoss EAP XP"
+  language: "java"
+  website: https://access.redhat.com/products/red-hat-jboss-enterprise-application-platform/
+starterProjects:
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile Config Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-config
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile Fault Tolerance Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-fault-tolerance
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile Health Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-health
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile JWT Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-jwt
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile Metrics Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-metrics
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile OpenAPI Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-openapi
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile OpenTracing Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-opentracing
+  - name: microprofile-config
+    description: EAP XP 2.0 Eclipse Microprofile REST Client Quickstart
+    git:
+      checkoutFrom:
+        remote: jboss-developer
+        revision: xp-2.0.x
+      remotes:
+        jboss-developer: https://github.com/jboss-developer/jboss-eap-quickstarts.git
+    subDir: microprofile-rest-client
+components:
+  - name: eap-xp
+    container:
+      image: registry.redhat.io/jboss-eap-7/eap-xp2-openjdk11-openshift-rhel8
+      memoryLimit: 1512Mi
+      mountSources: true
+      volumeMounts:
+        - name: m2-repository
+          path: /home/jboss/.m2/repository
+      env:
+        - name: GC_METASPACE_SIZE
+          value: '96'
+        - name: GC_MAX_METASPACE_SIZE
+          value: '256'
+        - name: GALLEON_PROVISION_LAYERS
+          value: 'jaxrs-server,microprofile-platform'
+        - name: S2I_DESTINATION_DIR
+          value: '/projects'
+        - name: STANDALONE_RESTORE
+          value: /home/jboss/.m2/.lucky
+#Overriding s2i image config to use the copied contents and thus avoid the file permissions issue.
+        - name: GALLEON_LOCAL_MAVEN_REPO
+          value: '/tmp/galleon-m2-repository'
+        - name: JBOSS_HOME
+          value: '/projects/eap'
+      endpoints:
+        - name: 'http'
+          targetPort: 8080
+  - name: m2-repository
+    volume:
+      size: 3Gi
+  - name: jaeger
+    container:
+      image: quay.io/jaegertracing/all-in-one:1.21.0
+      memoryLimit: 128Mi
+      endpoints:
+        - name: 'tracing-ui'
+          targetPort: 16686
+commands:
+  - id: build
+    composite:
+      label: Build and deploy on JBoss EAP-XP Server.
+      commands:
+        - compile
+        - copy-artifact
+      parallel: false
+      group:
+        kind: build
+        isDefault: true
+  - id: compile
+    exec:
+      label: Compile and package the application
+      component: eap-xp
+      commandLine: mvn -Dmaven.test.skip=true -Dcom.redhat.xpaas.repo.jbossorg -s /home/jboss/.m2/settings.xml clean package
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: build
+        isDefault: false
+  - id: copy-artifact
+    exec:
+      label: Copy application artifact
+      component: eap-xp
+      commandLine: cp target/*.war $JBOSS_HOME/standalone/deployments/ROOT.war
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: build
+        isDefault: false
+  - id: run
+    exec:
+      label: Launch JBoss EAP-XP Server
+      component: eap-xp
+      commandLine: cp -f $STANDALONE_RESTORE/standalone-openshift.xml $JBOSS_HOME/standalone/configuration/standalone-openshift.xml && $JBOSS_HOME/bin/openshift-launch.sh
+      workingDir: $PROJECTS_ROOT
+      hotReloadCapable: true
+      group:
+        kind: run
+        isDefault: true
+  - id: debug
+    exec:
+      label: Launch JBoss EAP-XP Server with debug enabled
+      component: eap-xp
+      commandLine: cp -f $STANDALONE_RESTORE/standalone-openshift.xml $JBOSS_HOME/standalone/configuration/standalone-openshift.xml && $JBOSS_HOME/bin/openshift-launch.sh
+      workingDir: $PROJECTS_ROOT
+      hotReloadCapable: true
+      env:
+        - name: JAVA_OPTS_APPEND
+          value: '-Xrunjdwp:transport=dt_socket,address=0.0.0.0:$DEBUG_PORT,server=y,suspend=n -Dsun.util.logging.disableCallerCheck=true'
+      group:
+        kind: debug
+        isDefault: true
+  - id: provision-server
+    exec:
+      component: eap-xp
+      commandLine: /usr/local/s2i/assemble && cp -Rf $JBOSS_HOME .
+      workingDir: $PROJECTS_ROOT
+      env:
+        - name: JBOSS_HOME
+          value: '/tmp/eap'
+      group:
+        kind: build
+        isDefault: false
+  - id: store-config
+    exec:
+      component: eap-xp
+      commandLine: mkdir $STANDALONE_RESTORE && cp -f $JBOSS_HOME/standalone/configuration/standalone-openshift.xml $STANDALONE_RESTORE/standalone-openshift.xml
+      workingDir: $PROJECTS_ROOT
+      env:
+        - name: JBOSS_HOME
+          value: /tmp/eap
+      group:
+        kind: build
+        isDefault: false
+#Hack to avoid the file permissions issue with the random openshift user
+  - id: copy-galleon
+    exec:
+      component: eap-xp
+      commandLine: cp -Rf /opt/jboss/container/wildfly/s2i/galleon/galleon-m2-repository /tmp/. && cp -Rf /opt/eap /tmp/.
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: build
+        isDefault: false
+  - id: init-server
+    composite:
+      label: Provision JBoss EAP-XP Server on post-start.
+      commands:
+        - copy-galleon
+        - provision-server
+        - store-config
+      parallel: false
+      group:
+        kind: build
+        isDefault: false
+  - id: cleanup
+    exec:
+      component: eap-xp
+      commandLine: rm -Rf eap
+      workingDir: $PROJECTS_ROOT
+      group:
+        kind: build
+        isDefault: false
+events:
+  postStart:
+    - "init-server"


### PR DESCRIPTION
There's a few miscellaneous updates that this PR groups together:
- Adds missing JBoss stack. 
  - Looks like I missed this one when setting up the repo.
  - Comes from https://github.com/odo-devfiles/registry/pull/67
- Adds missing description to the other JBoss stack
  - Comes from the meta.yaml in https://github.com/odo-devfiles/registry/pull/67
- Updates to use a specific index server base image that doesn't have certain "Community Devfile Registry" fields set
  - Temporary workaround til https://github.com/devfile/api/issues/605 is merged
- Adds basic contributing.MD (same as devfile/registry repo)