### PR TITLE
Port registry tests over to the product registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ From there, push the container image to a container registry of your choice and 
 
 For contributing Devfile stacks to this registry, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+For testing devfile stacks in the registry, or devfile stacks that you are contributing, please see the [testing doc](tests/README.md).
 
 ## Reporting any issue
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,29 @@
+# Product Devfile Registry Testing
+
+## Prerequisites
+
+- OpenShift installed, and running.
+  - [CodeReady Containers](https://developers.redhat.com/products/codeready-containers/overview) is a good starting point if you don't want to install a full OpenShfit cluster.
+- odo v2 or later.
+- [yq](https://github.com/mikefarah/yq) v4.x
+
+## Running the tests
+
+1) Log in to a running OpenShift instance with `oc`.
+
+2) From the root of this repository, run `tests/test.sh`. 
+  
+    - The test script will validate each devfile stack under `stacks/` with odo, verifying that the stack can be used to build a starter project and that the application is properly built and exposed. 
+       - The test script checks for an HTTP 200 status code to determine "properly exposed".
+    - Each devfile stack **must** have at least one starter project specified in the devfile.yaml
+      - **Note:** The script will use `yq` to find the name of the first starter project and download it. 
+
+## Configuration:
+
+- Set `STACK=<path-to-stack-folder>` if you only want to test one specific test (rather than all of the stacks in this repository). 
+  - e.g. `STACK=stacks/java-jboss-eap-xp ./tests/test.sh`
+
+## Limitations
+
+- If there are multiple starter projects, odo will only use the first starter project mentioned.
+- Only `odo create`,  `odo url create`, and `odo push` are tested right now. If your devfile stack exposes additional functionality (such as debug, via `odo debug`), we recommend either manually testing that functionality, or setting up your own test scripts in the stack's repository

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+
+set -x
+DEVFILES_DIR="$(pwd)/stacks/"
+FAILED_TESTS=""
+
+getURLs() {
+    urls=$($ODO_PATH url list | awk '{ print $3 }' | tail -n +3 | tr '\n' ' ')
+    echo "$urls"
+}
+
+# periodicaly check url till it returns expected HTTP status
+# exit after 10 tries
+waitForHTTPStatus() {
+   url=$1
+   statusCode=$2
+
+    for i in $(seq 1 10); do
+        echo "try: $i"
+        content=$(curl -i "$url")
+        echo "Checking if $url is returning HTTP $statusCode"
+        echo "$content" | grep -q -E "HTTP/[0-9.]+ $statusCode"
+        retVal=$?
+        if [ $retVal -ne 0 ]; then
+            echo "ERROR not HTTP $statusCode"
+            echo "$content"
+        else
+            echo "OK HTTP $statusCode"
+            return 0
+        fi
+        sleep 10
+    done
+    return 1
+}
+
+# run test on devfile
+# parameters:
+# - name of a component and project 
+# - path to devfile.yaml
+test() {
+    devfileName=$1
+    devfilePath=$2
+
+    # remember if there was en error
+    error=false
+
+    tmpDir=$(mktemp -d)
+    cd "$tmpDir" || return 1
+
+    $ODO_PATH project create "$devfileName" || error=true
+    if $error; then
+        echo "ERROR project create failed"
+        FAILED_TESTS="$FAILED_TESTS $devfileName"
+        return 1
+    fi
+    
+    # Get the starter project name
+    starterProject=$($YQ_PATH e '.starterProjects[0].name' $devfilePath)
+    if [ "$REGISTRY" = "local" ]; then
+      $ODO_PATH create "$devfileName" --devfile "$devfilePath" --starter $starterProject || error=true
+    else
+      $ODO_PATH create "$devfileName" --starter $starterProject || error=true
+    fi
+
+    if $error; then
+        echo "ERROR create failed"
+        $ODO_PATH project delete -f "$devfileName"
+        FAILED_TESTS="$FAILED_TESTS $devfileName"
+        return 1
+    fi
+
+    if [ "$ENV" = "minikube" ]; then
+        # ToDo: Clean up, I'm not happy about having specific checks for the stacks with multiple ports
+        # But since we're testing against minikube, we need to specifically create the URL/ingress before pushing
+        # And if there's multiple ports in the devfile, a port must be specified.
+        if [ "$devfileName" = "java-wildfly" ] || [ "$devfileName" = "java-wildfly-bootable-jar" ]; then
+            $ODO_PATH url create --host "$(minikube ip).nip.io" --port 8080 || error=true
+            $ODO_PATH url create --host "$(minikube ip).nip.io" --port 16686 || error=true
+        else
+            $ODO_PATH url create --host "$(minikube ip).nip.io" || error=true
+        fi
+        if $error; then
+            echo "ERROR url create failed"
+            $ODO_PATH project delete -f "$devfileName"
+            FAILED_TESTS="$FAILED_TESTS $devfileName"
+            return 1
+        fi
+    fi
+
+    $ODO_PATH push || error=true
+    if $error; then
+        echo "ERROR push failed"
+        $ODO_PATH delete -f -a || error=true
+        $ODO_PATH project delete -f "$devfileName"
+        FAILED_TESTS="$FAILED_TESTS $devfileName"
+        return 1
+    fi
+
+    # check if application is responding
+    urls=$(getURLs)
+
+    for url in $urls; do
+        statusCode=200
+        
+        waitForHTTPStatus "$url" "$statusCode"
+        if [ $? -ne 0 ]; then
+            echo "ERROR unable to get working url"
+            $ODO_PATH project delete -f "$devfileName"
+            FAILED_TESTS="$FAILED_TESTS $devfileName"
+            error=true
+            return 1
+        fi
+    done
+
+    # kill -9 $CPID
+    $ODO_PATH delete -f -a || error=true
+    $ODO_PATH project delete -f "$devfileName"
+
+    if $error; then
+        echo "FAIL"
+        # record failed test
+        FAILED_TESTS="$FAILED_TESTS $devfileName"
+        return 1
+    fi
+
+    return 0
+}
+
+if [ -z $ODO_PATH ]; then
+  ODO_PATH=odo
+fi
+if [ -z $YQ_PATH ]; then
+  YQ_PATH=yq
+fi
+
+if [ -z $REGISTRY ]; then
+  REGISTRY=local
+fi
+if [ "$REGISTRY" != "local" ] && [ "$REGISTRY" != "remote" ]; then
+  echo "ERROR: Allowed values for REGISTRY are either \"local\" (default) or \"remote\"."
+  exit 1
+fi
+
+
+# If $STACK is set, test only that specific stack
+# Otherwise, test the other stacks.
+if [ $STACK ]; then
+  stackFolder="$(realpath $(dirname $STACK))"
+  devfile_name="$(basename $STACK)"
+  devfile_path=$stackFolder/$devfile_name/devfile.yaml
+  test "$devfile_name" "$devfile_path"
+else
+  for devfile_dir in $(find $DEVFILES_DIR -maxdepth 1 -type d ! -path $DEVFILES_DIR); do
+      devfile_name="$(basename $devfile_dir)"
+      devfile_path=$devfile_dir/devfile.yaml
+
+      test "$devfile_name" "$devfile_path"
+  done
+fi
+
+
+# remember if there was an error so the script can exist with proper exit code at the end
+error=false
+
+# print out which tests failed
+if [ "$FAILED_TESTS" != "" ]; then
+    error=true
+    echo "FAILURE: FAILED TESTS: $FAILED_TESTS"
+    exit 1
+fi
+
+exit 0

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -49,7 +49,7 @@ test() {
 
     $ODO_PATH project create "$devfileName" || error=true
     if $error; then
-        echo "ERROR project create failed"
+        echo "ERROR odo project create failed"
         FAILED_TESTS="$FAILED_TESTS $devfileName"
         return 1
     fi
@@ -63,7 +63,7 @@ test() {
     fi
 
     if $error; then
-        echo "ERROR create failed"
+        echo "ERROR odo create failed"
         $ODO_PATH project delete -f "$devfileName"
         FAILED_TESTS="$FAILED_TESTS $devfileName"
         return 1
@@ -80,7 +80,7 @@ test() {
             $ODO_PATH url create --host "$(minikube ip).nip.io" || error=true
         fi
         if $error; then
-            echo "ERROR url create failed"
+            echo "ERROR odo url create failed"
             $ODO_PATH project delete -f "$devfileName"
             FAILED_TESTS="$FAILED_TESTS $devfileName"
             return 1
@@ -89,7 +89,7 @@ test() {
 
     $ODO_PATH push || error=true
     if $error; then
-        echo "ERROR push failed"
+        echo "ERROR odo push failed"
         $ODO_PATH delete -f -a || error=true
         $ODO_PATH project delete -f "$devfileName"
         FAILED_TESTS="$FAILED_TESTS $devfileName"
@@ -159,7 +159,7 @@ else
 fi
 
 
-# remember if there was an error so the script can exist with proper exit code at the end
+# remember if there was an error so the script can exit with proper exit code at the end
 error=false
 
 # print out which tests failed

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -158,13 +158,8 @@ else
   done
 fi
 
-
-# remember if there was an error so the script can exit with proper exit code at the end
-error=false
-
 # print out which tests failed
 if [ "$FAILED_TESTS" != "" ]; then
-    error=true
     echo "FAILURE: FAILED TESTS: $FAILED_TESTS"
     exit 1
 fi


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/devfile-registry/issues/10

Ports over the registry test script from [devfile/registry](https://github.com/devfile/registry/tree/main/tests), with the following modifications:
- OpenShift / CRC only
- Support for testing only one devfile stack, rather than the whole
   - I'll probably port this change back over to the community registry later, as this would be useful there too.
   
At the moment, this test script does not yet run on PR builds. I'll need to work with QE to get it running on the OpenShift CI once this PR is merged.