### PR TITLE
Enable viewer telemetry for the product registry

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -15,6 +15,6 @@ RUN git clone https://github.com/devfile/registry-support.git /registry-support
 # Run the registry build tools
 RUN /registry-support/build-tools/build.sh /registry /build
 
-FROM quay.io/devfile/devfile-index-base:no-community
+FROM quay.io/devfile/devfile-index-base:no-community-2d64d8ef1368912f623400ea8cbcd50891a8806a
 
 COPY --from=builder /build /registry

--- a/.ci/deploy/devfile-registry.yaml
+++ b/.ci/deploy/devfile-registry.yaml
@@ -92,6 +92,8 @@ objects:
               value: ${ENABLE_TELEMETRY}
             - name: REGISTRY_NAME
               value: ${REGISTRY_NAME}
+            - name: ANALYTICS_WRITE_KEY
+              value: ${ANALYTICS_WRITE_KEY}
           volumeMounts:
           - name: viewer-config
             mountPath: "/app/config"
@@ -178,8 +180,9 @@ objects:
 
     devfile-registry-hosts.json: |
       {
-        "Community": {
-          "url": "http://localhost:8080"
+        "ProductRegistry": {
+          "url": "http://localhost:8080",
+          "alias": "${REGISTRY_HOST_ALIAS}"
         }
       }
 
@@ -232,3 +235,15 @@ parameters:
   value: devfile-community-registry
   displayName: Devfile registry name
   description: The registry name that is used as identifier for devfile telemetry
+- name: REGISTRY_NAME
+  value: devfile-community-registry
+  displayName: Devfile registry name
+  description: The registry name that is used as identifier for devfile telemetry
+- name: REGISTRY_HOST_ALIAS
+  value: https://devfile-registry.redhat.com
+  displayName: Devfile registry hostname alias
+  description: The hostname alias to pass in to the devfile registry viewer's config.
+- name: ANALYTICS_WRITE_KEY
+  value: S2rfQJo8xA9nyLhdY2CnTrWqlUgHqmwq
+  displayName: Public write key for segment.io
+  description: The public write key to send viewer analytics to segment.io


### PR DESCRIPTION
- Updates the base image to one with a newer registry viewer instance
- Updates the OpenShift template to include the registry host alias and analytics write key