### PR TITLE
Update base image tag in pipeline dockerfile

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -15,6 +15,6 @@ RUN git clone https://github.com/devfile/registry-support.git /registry-support
 # Run the registry build tools
 RUN /registry-support/build-tools/build.sh /registry /build
 
-FROM quay.io/devfile/devfile-index-base:no-community-47b3ffaeadba7babb7075e0576584cfaa3f64341
+FROM quay.io/devfile/devfile-index-base:next
 
 COPY --from=builder /build /registry


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

# Description

Updates the image tag used on the registry base image so product registry uses the same version of the registry index server as the community registry. This change is require for changes in PR #16 to work properly.
